### PR TITLE
Relax omniauth dependency

### DIFF
--- a/omniauth-openid-connect.gemspec
+++ b/omniauth-openid-connect.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'omniauth', '~> 1.1'
+  spec.add_dependency 'omniauth', '~> 1.0', '>= 1.1.0'
   spec.add_dependency 'openid_connect', '~> 0.8.0'
   spec.add_dependency 'addressable', '~> 2.3'
   spec.add_development_dependency "bundler", "~> 1.5"


### PR DESCRIPTION
This relaxes the omniauth dependency since we use a more recent version in the core and other plugins.

/cc @machisuji 
