### PR TITLE
Fix formatting `acr_values` query parameter

### DIFF
--- a/lib/omniauth/openid_connect/version.rb
+++ b/lib/omniauth/openid_connect/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module OpenIDConnect
-    VERSION = '0.3.0'
+    VERSION = '0.3.1'
   end
 end

--- a/lib/omniauth/openid_connect/version.rb
+++ b/lib/omniauth/openid_connect/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module OpenIDConnect
-    VERSION = '0.3.1'
+    VERSION = '0.3.3'
   end
 end

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -125,9 +125,9 @@ module OmniAuth
           prompt: options.prompt,
           nonce: (new_nonce if options.send_nonce),
           hd: options.hd,
-          acr_values: options.acr_values
+          acr_values: Array(options.acr_values).join(" ")
         }
-        client.authorization_uri(opts.reject { |k, v| v.nil? })
+        client.authorization_uri(opts.reject { |_k, v| v.nil? })
       end
 
       def public_key

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -125,6 +125,7 @@ module OmniAuth
           prompt: options.prompt,
           nonce: (new_nonce if options.send_nonce),
           hd: options.hd,
+          acr_values: options.acr_values
         }
         client.authorization_uri(opts.reject { |k, v| v.nil? })
       end

--- a/omniauth-openid-connect.gemspec
+++ b/omniauth-openid-connect.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'omniauth', '~> 1.6.1'
+  spec.add_dependency 'omniauth', '~> 1.8.1'
   spec.add_dependency 'openid_connect', '~> 1.1.6'
   spec.add_dependency 'addressable', '~> 2.5'
   spec.add_development_dependency 'bundler', '~> 1.5'


### PR DESCRIPTION
Provide array of `acr_values` query string parameter as space formatted string.