### PR TITLE
Handle azure

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -61,7 +61,7 @@ module OmniAuth
       end
 
       extra do
-        { raw_info: fix_user_info(user_info).raw_attributes }
+        { raw_info: user_info.raw_attributes }
       end
 
       credentials do
@@ -153,16 +153,21 @@ module OmniAuth
       end
 
       def user_info
-        @user_info ||= access_token.userinfo!
+        @user_info ||= fix_user_info(access_token.userinfo!)
       end
 
-      ##
-      # Google sends the string "true" as the value for the field 'email_verified' while a boolean is expected.
       def fix_user_info(user_info)
+        # Google sends the string "true" as the value for the field 'email_verified' while a boolean is expected.
         if user_info.email_verified.is_a? String
           user_info.email_verified = (user_info.email_verified == "true")
         end
         user_info.gender = nil # in case someone picks something else than male or female, we don't need it anyway
+
+        # Azure doesn't provide an email by default, but unique_name is the email used to login
+        if user_info.email.blank? && user_info.raw_attributes.has_key?("unique_name")
+          user_info.email = user_info.raw_attributes["unique_name"]
+        end
+
         user_info
       end
 


### PR DESCRIPTION
Azure doesn't seem to send an email by default in the JWT claims. Had a long discussion with a support guy from Azure who was unable to say why the email is empty. But since `unique_name` is present and is supposed to contain the email used to log into Azure, it should be enough...