### PR TITLE
Catch relevant error during callback phase

### DIFF
--- a/lib/omniauth/openid_connect/version.rb
+++ b/lib/omniauth/openid_connect/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module OpenIDConnect
-    VERSION = '0.4.0'
+    VERSION = '0.4.1'
   end
 end

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -100,7 +100,7 @@ module OmniAuth
 
           super
         end
-      rescue CallbackError => e
+      rescue CallbackError, Rack::OAuth2::Client::Error => e
         fail!(:invalid_credentials, e)
       rescue ::Timeout::Error, ::Errno::ETIMEDOUT => e
         fail!(:timeout, e)


### PR DESCRIPTION
I am not sure under which circumstances the original error condition yielding the CallbackError occurs. The newly added error occurs when we try to exchange the access token, but the client credentials are wrong. Thus I assume that we'd receive the same for all errors specified by the OAuth 2.0 spec.

## Ticket

https://community.openproject.org/projects/openproject/work_packages/59960