### PR TITLE
Do not escape claims twice

### DIFF
--- a/lib/omniauth/openid_connect/version.rb
+++ b/lib/omniauth/openid_connect/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module OpenIDConnect
-    VERSION = '0.4.1'
+    VERSION = '0.4.2'
   end
 end

--- a/lib/omniauth/strategies/openid_connect/claims.rb
+++ b/lib/omniauth/strategies/openid_connect/claims.rb
@@ -40,7 +40,7 @@ module OmniAuth
         def claims_auth_param
           return nil unless claims?
 
-          ERB::Util.url_encode Hash(claims).to_json
+          Hash(claims).to_json
         end
 
         def claims

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -19,7 +19,7 @@ module OmniAuth
       end
 
       def test_request_phase_with_claims
-        expected_redirect = /^https:\/\/example\.com\/authorize\?claims=%257B%2522id_token%2522%253A%257B%2522acr%2522%253A%257B%2522essential%2522%253Atrue%252C%2522values%2522%253A%255B%2522phr%2522%252C%2522phrh%2522%255D%257D%257D%257D&client_id=1234&nonce=\w{32}&response_type=code&scope=openid&state=\w{32}$/
+        expected_redirect = /^https:\/\/example\.com\/authorize\?claims=%7B%22id_token%22%3A%7B%22acr%22%3A%7B%22essential%22%3Atrue%2C%22values%22%3A%5B%22phr%22%2C%22phrh%22%5D%7D%7D%7D&client_id=1234&nonce=\w{32}&response_type=code&scope=openid&state=\w{32}$/
         strategy.options.issuer = 'example.com'
         strategy.options.client_options.host = 'example.com'
         strategy.options.claims = {
@@ -35,7 +35,7 @@ module OmniAuth
       end
 
       def test_request_phase_with_claims_passed_as_json
-        expected_redirect = /^https:\/\/example\.com\/authorize\?claims=%257B%2522id_token%2522%253A%257B%2522acr%2522%253A%257B%2522essential%2522%253Atrue%252C%2522values%2522%253A%255B%2522phr%2522%252C%2522phrh%2522%255D%257D%257D%257D&client_id=1234&nonce=\w{32}&response_type=code&scope=openid&state=\w{32}$/
+        expected_redirect = /^https:\/\/example\.com\/authorize\?claims=%7B%22id_token%22%3A%7B%22acr%22%3A%7B%22essential%22%3Atrue%2C%22values%22%3A%5B%22phr%22%2C%22phrh%22%5D%7D%7D%7D&client_id=1234&nonce=\w{32}&response_type=code&scope=openid&state=\w{32}$/
         strategy.options.issuer = 'example.com'
         strategy.options.client_options.host = 'example.com'
         strategy.options.claims = {


### PR DESCRIPTION
Escaping of authorize_options happens by the main gem already, so we don't have to do that manually beforehand. The previous implementation led to double escaping, e.g. %22 became %2522.

This error was also reflected in all test expectations.

# Ticket
https://community.openproject.org/wp/69079